### PR TITLE
Unify docker build and push

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -18,16 +18,31 @@ tasks:
 
     owner: ${event.sender.login}@users.noreply.github.com
 
+    shouldPush:
+      $if: 'event.repository.html_url != "https://github.com/mozilla-releng/k8s-autoscale"'
+      then:
+        false
+      else:
+        $if: 'tasks_for == "github-release"'
+        then: true
+        else:
+          $if: 'event.ref in ["refs/heads/master", "refs/heads/dev"]'
+          then: true
+          else: false
+
     docker_tag:
       $if: 'tasks_for == "github-pull-request"'
       then: pull-request
       else:
-        $if: 'tasks_for == "github-push"'
-        then:
-          $if: 'event.ref[:10] == "refs/tags/"'
-          then: ${event.ref[10:]} # strip "refs/tags/"
-          else: ${event.ref[11:]} # strip "refs/heads/"
-        else: "v${event.release.tag_name}" # prefix the version with "v"
+        $if: 'tasks_for == "github-release"'
+        then: "v${event.release.tag_name}" # prefix the version with "v"
+        else: # push
+          $if: 'event.ref == "refs/heads/master"'
+          then: latest
+          else:
+            $if: 'event.ref == "refs/heads/dev"'
+            then: dev
+            else: garbage
 
   in:
     - taskId: '${as_slugid("py37")}'
@@ -54,78 +69,85 @@ tasks:
         owner: ${owner}
         source: ${repository}/raw/${head_rev}/.taskcluster.yml
 
-    - taskId: '${as_slugid("docker_build")}'
-      dependencies:
-        - '${as_slugid("py37")}'
-      provisionerId: aws-provisioner-v1
-      workerType: github-worker
-      created: {$fromNow: ''}
-      deadline: {$fromNow: '4 hours'}
-      payload:
-        features:
-          dind: true
-        maxRunTime: 3600
-        image: mozillareleases/python-test-runner
-        command:
-          - bash
-          - -ce
-          - >-
-            git clone ${repository} /src &&
-            cd /src &&
-            git config advice.detachedHead false &&
-            git checkout ${head_rev} &&
-            docker.d/generate_version_json.sh &&
-            cat version.json &&
-            docker build -f Dockerfile -t mozilla/releng-k8s-autoscale:${docker_tag} . &&
-            docker save mozilla/releng-k8s-autoscale:${docker_tag} > /tmp/image.tar &&
-            docker images --no-trunc mozilla/releng-k8s-autoscale | grep ${docker_tag}
-        artifacts:
-          public/image.tar:
-            expires: {$fromNow: '2 weeks'}
-            path: /tmp/image.tar
-            type: file
-      metadata:
-        name: docker build (${docker_tag})
-        description: build latest docker image (${docker_tag})
-        owner: ${owner}
-        source: ${repository}/raw/${head_rev}/.taskcluster.yml
-
-    - $if: 'tasks_for != "github-pull-request"'
+    - $if: 'shouldPush'
       then:
-        $if: 'repository == "https://github.com/mozilla-releng/k8s-autoscale"'
-        then:
-          taskId: '${as_slugid("docker_push")}'
-          dependencies:
-            - '${as_slugid("docker_build")}'
-          provisionerId: aws-provisioner-v1
-          workerType: github-worker
-          created: {$fromNow: ''}
-          deadline: {$fromNow: '4 hours'}
-          payload:
-            features:
-              # Needed for access to secret
-              taskclusterProxy: true
-              dind: true
-            maxRunTime: 3600
-            image: mozillareleases/python-test-runner
-            command:
-              - bash
-              - -ce
-              - >-
-                git clone ${repository} /src &&
-                cd /src &&
-                git config advice.detachedHead false &&
-                git checkout ${head_rev} &&
-                IMAGE_TASK_ID=${as_slugid("docker_build")}
-                SECRET_URL=http://taskcluster/secrets/v1/secret/project/releng/k8s-autoscale/deploy
-                DOCKERHUB_EMAIL=release+dockerhub+services@mozilla.com
-                DOCKERHUB_USER=mozillarelengservices
-                TAG=mozilla/releng-k8s-autoscale:${docker_tag}
-                ./docker.d/push_image.sh
-          scopes:
-            - secrets:get:project/releng/k8s-autoscale/deploy
-          metadata:
-            name: docker push (${docker_tag})
-            description: push docker image (${docker_tag})
-            owner: ${owner}
-            source: ${repository}/raw/${head_rev}/.taskcluster.yml
+        taskId: '${as_slugid("docker_push")}'
+        dependencies:
+          - '${as_slugid("py37")}'
+        provisionerId: aws-provisioner-v1
+        workerType: github-worker
+        created: {$fromNow: ''}
+        deadline: {$fromNow: '24 hours'}
+        payload:
+          features:
+            # Needed for access to secret
+            taskclusterProxy: true
+            dind: true
+          maxRunTime: 3600
+          image: mozillareleases/python-test-runner
+          env:
+            SECRET_URL: http://taskcluster/secrets/v1/secret/project/releng/k8s-autoscale/deploy
+            DOCKERHUB_EMAIL: release+dockerhub+services@mozilla.com
+            DOCKERHUB_USER: mozillarelengservices
+            TAG: mozilla/releng-k8s-autoscale:${docker_tag}
+          command:
+            - bash
+            - -ce
+            - >-
+              git clone ${repository} /src &&
+              cd /src &&
+              git config advice.detachedHead false &&
+              git checkout ${head_rev} &&
+              docker.d/generate_version_json.sh &&
+              cat version.json &&
+              docker build -f Dockerfile -t mozilla/releng-k8s-autoscale:${docker_tag} . &&
+              docker save mozilla/releng-k8s-autoscale:${docker_tag} > /tmp/image.tar &&
+              ./docker.d/push_image.sh
+          artifacts:
+            public/image.tar:
+              expires: {$fromNow: '8 weeks'}
+              path: /tmp/image.tar
+              type: file
+        scopes:
+          - secrets:get:project/releng/k8s-autoscale/deploy
+        metadata:
+          name: build and push docker image (${docker_tag})
+          description: build and push docker image (${docker_tag})
+          owner: ${owner}
+          source: ${repository}/raw/${head_rev}/.taskcluster.yml
+
+      else: # run docker build to verify it works
+        taskId: '${as_slugid("docker_build")}'
+        dependencies:
+          - '${as_slugid("py37")}'
+        provisionerId: aws-provisioner-v1
+        workerType: github-worker
+        created: {$fromNow: ''}
+        deadline: {$fromNow: '24 hours'}
+        payload:
+          features:
+            dind: true
+          maxRunTime: 3600
+          image: mozillareleases/python-test-runner
+          command:
+            - bash
+            - -ce
+            - >-
+              git clone ${repository} /src &&
+              cd /src &&
+              git config advice.detachedHead false &&
+              git checkout ${head_rev} &&
+              docker.d/generate_version_json.sh &&
+              cat version.json &&
+              docker build -f Dockerfile -t mozilla/releng-k8s-autoscale:${docker_tag} . &&
+              docker save mozilla/releng-k8s-autoscale:${docker_tag} > /tmp/image.tar
+          artifacts:
+            public/image.tar:
+              expires: {$fromNow: '2 weeks'}
+              path: /tmp/image.tar
+              type: file
+        metadata:
+          name: docker build (${docker_tag})
+          description: build docker image (${docker_tag})
+          owner: ${owner}
+          source: ${repository}/raw/${head_rev}/.taskcluster.yml

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -19,16 +19,19 @@ tasks:
     owner: ${event.sender.login}@users.noreply.github.com
 
     shouldPush:
-      $if: 'event.repository.html_url != "https://github.com/mozilla-releng/k8s-autoscale"'
-      then:
-        false
+      $if: 'tasks_for == "github-pull-request"'
+      then: false
       else:
-        $if: 'tasks_for == "github-release"'
-        then: true
+        $if: 'event.repository.html_url != "https://github.com/mozilla-releng/k8s-autoscale"'
+        then:
+          false
         else:
-          $if: 'event.ref in ["refs/heads/master", "refs/heads/dev"]'
+          $if: 'tasks_for == "github-release"'
           then: true
-          else: false
+          else:
+            $if: 'event.ref in ["refs/heads/master", "refs/heads/dev"]'
+            then: true
+            else: false
 
     docker_tag:
       $if: 'tasks_for == "github-pull-request"'

--- a/docker.d/push_image.sh
+++ b/docker.d/push_image.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-test $IMAGE_TASK_ID
 test $SECRET_URL
 test $DOCKERHUB_EMAIL
 test $DOCKERHUB_USER
@@ -8,10 +7,5 @@ test $TAG
 
 dockerhub_password=$(curl $SECRET_URL | python -c 'import json, sys; a = json.load(sys.stdin); print a["secret"]["docker"]["password"]')
 
-WORKDIR=$(mktemp -d)
-cd $WORKDIR
-
-curl -L -o image.tar https://queue.taskcluster.net/v1/task/$IMAGE_TASK_ID/artifacts/public/image.tar
-docker load < image.tar
 docker login -e $DOCKERHUB_EMAIL -u $DOCKERHUB_USER -p $dockerhub_password
 docker push $TAG


### PR DESCRIPTION
In order to pass cloudops image verification we need to print the image
digest in the log. The digest is printed as a part of `docker push` or
`docker pull` (it's a part of registry specification).