### PR TITLE
Bug 1580478 - add k8s options for balrogworkers.

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -11,3 +11,18 @@ worker_types:
         sla_seconds: 240
         capacity_ratio: 1.0
         min_replicas: 1
+
+
+worker_types:
+  - worker_type: gecko-1-balrog-dev
+    provisioner: scriptworker-k8s
+    deployment_namespace: dev-balrog
+    deployment_name: balrog-dev-relengworker-firefox-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 10
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 1

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -66,15 +66,54 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 1
 
-  - worker_type: gecko-t-balrog
+  - worker_type: gecko-3-balrog
+    provisioner: scriptworker-k8s
+    deployment_namespace: prod-balrog
+    deployment_name: balrog-prod-relengworker-firefox-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 20
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 1
+
+  - worker_type: gecko-1-balrog
     provisioner: scriptworker-k8s
     deployment_namespace: prod-balrog
     deployment_name: balrog-prod-relengworker-fake-firefox-1
     autoscale:
       algorithm: sla
       args:
-        max_replicas: 20
-        avg_task_duration: 120
-        sla_seconds: 240
+        max_replicas: 10
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 1
+
+  - worker_type: comm-3-balrog
+    provisioner: scriptworker-k8s
+    deployment_namespace: prod-balrog
+    deployment_name: balrog-prod-relengworker-thunderbird-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 10
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 1
+
+  - worker_type: comm-1-balrog
+    provisioner: scriptworker-k8s
+    deployment_namespace: prod-balrog
+    deployment_name: balrog-prod-relengworker-fake-thunderbird-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 10
+        avg_task_duration: 60
+        sla_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 1


### PR DESCRIPTION
@catlee 

For a regular beta release (including partner after >= b8), we have ~1200 beetmover jobs but  only ~500+ balrog ones. So definitely less resources needed in GCP, than beetmover so save $$$.
After some digging, here's some stats:

Old AWS puppet-based infrastructure:
- Beetmoverworkers -> 22 production, 10 in dev
- Balrogworkers -> 10 production, 10 in dev

Existing GCP-based infrastructure:
- Beetmoverworkers - max 40 replicas in production, max 20 in dev
- (proposal) Balrogworkers - max 20 replicas in production, max 10 in dev

Average job runtime in a beta:
- beetmover -> ~50 seconds => in cloudops-infra this is set to 120 seconds.
- balrog -> ~20 seconds => I've set this to 60 seconds to cover upper limit.

I've followed the practiuce of beetmover for adding in the same time the `comm` counterparts too to have them ready. They are in half as values compared to beetmover, because we don't need that many resources. I'd rather start with small values and iterate so we can adjust those if needed.
