### PR TITLE
Bug 1542819 - add k8s options for signingworkers.

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -26,3 +26,17 @@ worker_types:
         sla_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 1
+
+worker_types:
+  - worker_type: gecko-t-signing-dev
+    provisioner: scriptworker-k8s
+    deployment_namespace: dev-signing
+    deployment_name: signing-dev-relengworker-firefox-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 20
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 1

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -131,19 +131,15 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 1
 
-  # TODO: Once we add definitions for production signing in https://github.com/mozilla-services/cloudops-infra/blob/master/projects/relengworker/k8s/values/signing.yaml#L14
-  ## we should uncomment the bellow block
-  ## add something similar for other products (mobile, Thunderbird, etc)
-  #
-  #- worker_type: gecko-3-signing
-    #provisioner: scriptworker-k8s
-    #deployment_namespace: prod-signing
-    #deployment_name: signing-prod-relengworker-firefox-1
-    #autoscale:
-      #algorithm: sla
-      #args:
-        #max_replicas: 40
-        #avg_task_duration: 60
-        #sla_seconds: 120
-        #capacity_ratio: 1.0
-        #min_replicas: 1
+  - worker_type: gecko-3-signing
+    provisioner: scriptworker-k8s
+    deployment_namespace: prod-signing
+    deployment_name: signing-prod-relengworker-firefox-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 40
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 1

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -117,3 +117,33 @@ worker_types:
         sla_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 1
+
+  - worker_type: gecko-t-signing
+    provisioner: scriptworker-k8s
+    deployment_namespace: prod-signing
+    deployment_name: signing-prod-relengworker-fake-firefox-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 20
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 1
+
+  # TODO: Once we add definitions for production signing in https://github.com/mozilla-services/cloudops-infra/blob/master/projects/relengworker/k8s/values/signing.yaml#L14
+  ## we should uncomment the bellow block
+  ## add something similar for other products (mobile, Thunderbird, etc)
+  #
+  #- worker_type: gecko-3-signing
+    #provisioner: scriptworker-k8s
+    #deployment_namespace: prod-signing
+    #deployment_name: signing-prod-relengworker-firefox-1
+    #autoscale:
+      #algorithm: sla
+      #args:
+        #max_replicas: 40
+        #avg_task_duration: 60
+        #sla_seconds: 120
+        #capacity_ratio: 1.0
+        #min_replicas: 1


### PR DESCRIPTION
@catlee 

Stats:
* average signing task is <30 seconds (measured thru my scripts for a couple of them in a regular beta) - so let's double the upper limit to 60 seconds
* we have 20 dev depsigning workers so let's keep that for fakeprod and dev
* we have 22 production workers so let's bump this to 40 for future production (blocked on adding the deployment in GCP so commented for now)
