### PR TITLE
Add autoscaling for addon

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -117,3 +117,29 @@ worker_types:
         sla_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 1
+
+  - worker_type: gecko-3-addon
+    provisioner: scriptworker-k8s
+    deployment_namespace: prod-addon
+    deployment_name: addon-prod-relengworker-firefox-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 10
+        avg_task_duration: 240
+        sla_seconds: 480
+        capacity_ratio: 1.0
+        min_replicas: 1
+
+  - worker_type: gecko-1-addon
+    provisioner: scriptworker-k8s
+    deployment_namespace: prod-addon
+    deployment_name: addon-prod-relengworker-fake-firefox-1 
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 10
+        avg_task_duration: 240
+        sla_seconds: 480
+        capacity_ratio: 1.0
+        min_replicas: 1


### PR DESCRIPTION
Picking the avg_task_duration is a bit tricky. The median job time varies between devedition and firefox for 70.0b12 - 1m 0s vs 4m40s - as if they are doing different amount of work but the same # of xpi are being submitted. I've tended towards the Firefox value by taking 4m. A failing job runs out of retries after ~13 minutes.

We have 4 instances at the moment, and the l10n chunks tend to finish in a fairly small time window, so a max_replicas of 10 should mean higher throughput. We shall to see if amo responds ok to that.