### PR TITLE
Explicitly specify TC root URL per worker type

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -1,6 +1,7 @@
 worker_types:
   - worker_type: gecko-1-beetmover-dev
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: dev-beetmover
     deployment_name: beetmover-dev-relengworker-firefox-1
     autoscale:
@@ -16,6 +17,7 @@ worker_types:
 worker_types:
   - worker_type: gecko-1-balrog-dev
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: dev-balrog
     deployment_name: balrog-dev-relengworker-firefox-1
     autoscale:
@@ -30,6 +32,7 @@ worker_types:
 worker_types:
   - worker_type: gecko-t-signing-dev
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: dev-signing
     deployment_name: signing-dev-relengworker-firefox-1
     autoscale:

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -2,6 +2,7 @@ worker_types:
 
   - worker_type: appservices-3-beetmover
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-beetmover
     deployment_name: beetmover-prod-relengworker-applicationservices-1
     autoscale:
@@ -15,6 +16,7 @@ worker_types:
 
   - worker_type: gecko-3-beetmover
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-beetmover
     deployment_name: beetmover-prod-relengworker-firefox-1
     autoscale:
@@ -29,6 +31,7 @@ worker_types:
 
   - worker_type: mobile-3-beetmover
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-beetmover
     deployment_name: beetmover-prod-relengworker-mobile-1
     autoscale:
@@ -42,6 +45,7 @@ worker_types:
 
   - worker_type: comm-3-beetmover
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-beetmover
     deployment_name: beetmover-prod-relengworker-thunderbird-1
     autoscale:
@@ -55,6 +59,7 @@ worker_types:
 
   - worker_type: gecko-1-beetmover
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-beetmover
     deployment_name: beetmover-prod-relengworker-fake-firefox-1
     autoscale:
@@ -68,6 +73,7 @@ worker_types:
 
   - worker_type: gecko-3-balrog
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-balrog
     deployment_name: balrog-prod-relengworker-firefox-1
     autoscale:
@@ -81,6 +87,7 @@ worker_types:
 
   - worker_type: gecko-1-balrog
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-balrog
     deployment_name: balrog-prod-relengworker-fake-firefox-1
     autoscale:
@@ -94,6 +101,7 @@ worker_types:
 
   - worker_type: comm-3-balrog
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-balrog
     deployment_name: balrog-prod-relengworker-thunderbird-1
     autoscale:
@@ -107,6 +115,7 @@ worker_types:
 
   - worker_type: comm-1-balrog
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-balrog
     deployment_name: balrog-prod-relengworker-fake-thunderbird-1
     autoscale:
@@ -120,6 +129,7 @@ worker_types:
 
   - worker_type: gecko-3-addon
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-addon
     deployment_name: addon-prod-relengworker-firefox-1
     autoscale:
@@ -133,6 +143,7 @@ worker_types:
 
   - worker_type: gecko-1-addon
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-addon
     deployment_name: addon-prod-relengworker-fake-firefox-1
     autoscale:
@@ -146,6 +157,7 @@ worker_types:
 
   - worker_type: gecko-t-signing
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-signing
     deployment_name: signing-prod-relengworker-fake-firefox-1
     autoscale:
@@ -159,6 +171,7 @@ worker_types:
 
   - worker_type: gecko-3-signing
     provisioner: scriptworker-k8s
+    root_url: "https://taskcluster.net"
     deployment_namespace: prod-signing
     deployment_name: signing-prod-relengworker-firefox-1
     autoscale:

--- a/k8s_autoscale/main.py
+++ b/k8s_autoscale/main.py
@@ -8,7 +8,6 @@ from k8s_autoscale.sla import get_new_worker_count
 from taskcluster import Queue
 
 logger = get_logger()
-q = Queue({"rootUrl": "https://taskcluster.net"})
 
 
 def autoscale(config):
@@ -79,7 +78,8 @@ def handle_worker_type(cfg):
     log = log.bind(capacity=capacity)
 
     log.info("Checking pending")
-    pending = q.pendingTasks(cfg["provisioner"], cfg["worker_type"])["pendingTasks"]
+    queue = Queue({"rootUrl": cfg["root_url"]})
+    pending = queue.pendingTasks(cfg["provisioner"], cfg["worker_type"])["pendingTasks"]
     log = log.bind(pending=pending)
     log.info("Calculated desired replica count")
     desired = get_new_worker_count(pending, running, cfg["autoscale"]["args"])


### PR DESCRIPTION
This will let us set different root urls per worker type, so we can mix
and match TC clusters using the same autoscaling deployment.