### PR TITLE
Bug 1596439 - Bring the number of mobile BMs back to 20

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -37,7 +37,7 @@ worker_types:
     autoscale:
       algorithm: sla
       args:
-        max_replicas: 2
+        max_replicas: 20
         avg_task_duration: 120
         sla_seconds: 240
         capacity_ratio: 1.0


### PR DESCRIPTION
Follows #65 up. Scriptworker 29.0.1+ has been deployed, so we shouldn't hammer the Github non-official endpoint as much as we did. Therefore, we can bring all the workers back and see how this goes. 