### PR TITLE
Add missing comm-1 worker types.

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -43,6 +43,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: comm-1-beetmover
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-beetmover
+    deployment_name: beetmover-prod-relengworker-firefoxci-comm-1-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 5
+        avg_task_duration: 120
+        sla_seconds: 240
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: comm-3-beetmover
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"
@@ -230,6 +244,20 @@ worker_types:
     root_url: "https://firefox-ci-tc.services.mozilla.com"
     deployment_namespace: prod-beetmover
     deployment_name: beetmover-prod-relengworker-firefoxci-mobile-1-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 1
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
+  - worker_type: comm-1-bouncer
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-bouncer
+    deployment_name: bouncer-prod-relengworker-firefoxci-comm-1-1
     autoscale:
       algorithm: sla
       args:
@@ -496,6 +524,20 @@ worker_types:
     root_url: "https://firefox-ci-tc.services.mozilla.com"
     deployment_namespace: prod-signing
     deployment_name: signing-prod-relengworker-firefoxci-mobile-t-1
+    autoscale:
+      algorithm: sla
+      args:
+        max_replicas: 1
+        avg_task_duration: 60
+        sla_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
+  - worker_type: comm-1-tree
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-tree
+    deployment_name: tree-prod-relengworker-firefoxci-comm-1-1
     autoscale:
       algorithm: sla
       args:


### PR DESCRIPTION
I'm working on being able to more completely test the Thunderbird release process using the Try server. The process stalls at the moment due to missing these worker types. Addresses issue  #75.
Are there other places these need to be added?