### PR TITLE
Bump mobile-3-beetmover workers

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -37,7 +37,7 @@ worker_types:
     autoscale:
       algorithm: sla
       args:
-        max_replicas: 2
+        max_replicas: 5
         avg_task_duration: 120
         sla_seconds: 240
         capacity_ratio: 1.0


### PR DESCRIPTION
Generating`maven-metadata.xml` had a few hiccups recently, all of which were resolved, AFAIK:
1. wrong `TESTING` within appservices that was polluting production buckets
2. invalidate once per POM file uploaded, rather than six times.

Given this, I think we can gradually bump the number of workers here to offer a better experience to AC releases and snapshots.