### PR TITLE
Reduce balrogworkers until we have a new blob upload gear

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -93,7 +93,7 @@ worker_types:
     autoscale:
       algorithm: sla
       args:
-        max_replicas: 25
+        max_replicas: 15
         avg_task_duration: 60
         sla_seconds: 120
         capacity_ratio: 1.0


### PR DESCRIPTION
We currently have 25 balrogworkers. In the old AWS world we used to have 12 and we almost never had occurrences of `400 - BAD REQUEST` (which are due to the race condition in download/merging the blob). With 40-60 balrogworkers, we used to see this a lot. But even with 25 we still see some every two weeks (check https://bugzilla.mozilla.org/show_bug.cgi?id=1591373 for stats). In order to get rid of those altogether, we should simply come back to 15. It's still fast enough since the balrog tasks are leaf nodes anyway and not blocking anything else.