### PR TITLE
Update replicas for gecko-3-tree workers

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -611,8 +611,8 @@ worker_types:
     autoscale:
       algorithm: sla
       args:
-        max_replicas: 1
-        avg_task_duration: 60
+        max_replicas: 3
+        avg_task_duration: 300
         sla_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 0


### PR DESCRIPTION
Concurrency issues with only one replica, for example:

    provisioner      workertype   taskid                 scheduled                   started                     resolved
    scriptworker-k8s gecko-3-tree Hk_97QeUT6KJ-q7TMX3xvw 2020-04-19 13:46:27.399 UTC 2020-04-19 13:49:11.122 UTC 2020-04-19 13:55:19.629 UTC
    scriptworker-k8s gecko-3-tree MYOL7CJERTa7LC7DKbtkhg 2020-04-19 13:46:55.699 UTC 2020-04-19 13:55:31.627 UTC 2020-04-19 13:59:46.203 UTC
    scriptworker-k8s gecko-3-tree dxTuaAGgQNKiFIVnscEmww 2020-04-19 13:47:02.525 UTC 2020-04-19 14:00:00.392 UTC 2020-04-19 14:04:10.932 UTC

l10n-bumper also runs for about five minutes. The merge day tasks take longer, I don't know if this should influence the `avg_task_duration`.  