### PR TITLE
SLA should be longer than task duration

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -613,7 +613,7 @@ worker_types:
       args:
         max_replicas: 3
         avg_task_duration: 300
-        sla_seconds: 120
+        sla_seconds: 600
         capacity_ratio: 1.0
         min_replicas: 0
 


### PR DESCRIPTION
There is a [check ](https://github.com/mozilla-releng/k8s-autoscale/blob/b63cdb0e3b690ca4fc916463f4f9339aafc979cd/src/k8s_autoscale/sla.py#L6) to ensure that the SLA is longer than the task duration. Should move this to the unittests...