### PR TITLE
Adjust balrogscript parameters for v2 api

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -121,8 +121,8 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 15
-        avg_task_duration: 60
+        max_replicas: 60
+        avg_task_duration: 8
         slo_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 0
@@ -135,8 +135,8 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 10
-        avg_task_duration: 60
+        max_replicas: 60
+        avg_task_duration: 8
         slo_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 0
@@ -149,8 +149,8 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 10
-        avg_task_duration: 60
+        max_replicas: 60
+        avg_task_duration: 8
         slo_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 0
@@ -163,8 +163,8 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 10
-        avg_task_duration: 60
+        max_replicas: 60
+        avg_task_duration: 8
         slo_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 0

--- a/configs/schema.yml
+++ b/configs/schema.yml
@@ -50,6 +50,7 @@ definitions:
       algorithm:
         type: string
         enum:
+          # https://en.wikipedia.org/wiki/Service-level_objective
           - slo
       args:
         schema:


### PR DESCRIPTION
Specifically:
* Reduce average run time (it's much lower now)
* Greatly increase pool size (race conditions are a thing of the past)

I think `slo_seconds` can stay the same -  there's no adjust our desired max pending time for these.

This shouldn't be merged until after we're using the v2 api for all
branches.