### PR TITLE
Bug 1786780 - Create mobile-t-signing-dev pool

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -55,6 +55,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: mobile-t-signing-dev
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: dev-signing
+    deployment_name: signing-dev-relengworker-firefoxci-mobile-t-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 20
+        avg_task_duration: 60
+        slo_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: gecko-1-addon-dev
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.


Must be merged alongside: 
 * https://github.com/mozilla-releng/scriptworker-scripts/pull/565
 * https://github.com/mozilla-services/cloudops-infra/pull/4365