### PR TITLE
Bug 1812986 - Remove unused gecko pushapk workers

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -97,20 +97,6 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
-  - worker_type: gecko-1-pushapk-dev
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: dev-pushapk
-    deployment_name: pushapk-dev-relengworker-firefoxci-gecko-1-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 1
-        avg_task_duration: 60
-        slo_seconds: 120
-        capacity_ratio: 1.0
-        min_replicas: 0
-
   - worker_type: gecko-1-pushflatpak-dev
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -365,34 +365,6 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
-  - worker_type: gecko-1-pushapk
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: prod-pushapk
-    deployment_name: pushapk-prod-relengworker-firefoxci-gecko-1-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 1
-        avg_task_duration: 60
-        slo_seconds: 120
-        capacity_ratio: 1.0
-        min_replicas: 0
-
-  - worker_type: gecko-3-pushapk
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: prod-pushapk
-    deployment_name: pushapk-prod-relengworker-firefoxci-gecko-3-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 1
-        avg_task_duration: 60
-        slo_seconds: 120
-        capacity_ratio: 1.0
-        min_replicas: 0
-
   - worker_type: mobile-1-pushapk
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
