### PR TITLE
Let the health check detect when we get stuck

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -222,3 +222,5 @@ worker_types:
         slo_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 0
+
+healthcheck_file: /app/healthy

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -812,3 +812,5 @@ worker_types:
         slo_seconds: 120
         capacity_ratio: 1.0
         min_replicas: 0
+
+healthcheck_file: /app/healthy

--- a/configs/schema.yml
+++ b/configs/schema.yml
@@ -9,6 +9,8 @@ properties:
     type: array
     items:
       $ref: '#/definitions/workerType'
+  healthcheck_file:
+    type: string
 
 definitions:
   workerType:

--- a/docker.d/healthcheck
+++ b/docker.d/healthcheck
@@ -1,2 +1,13 @@
 #!/bin/bash
+
+set -e
+
+# k8s-autoscale is running
 pgrep k8s_autoscale
+
+# and the flag file was touched less than 10 minutes ago
+FLAG_FILE_MAX_AGE_SEC=$((10 * 60))
+FLAG_FILE=/app/healthy
+NOW=$(date +%s)
+MTIME=$(stat -c %Y $FLAG_FILE)
+test $((NOW - MTIME)) -lt $FLAG_FILE_MAX_AGE_SEC

--- a/src/k8s_autoscale/cli.py
+++ b/src/k8s_autoscale/cli.py
@@ -22,7 +22,7 @@ def main(config):
     if os.environ.get("SENTRY_DSN") and os.environ.get("ENV"):
         configure_sentry(environment=os.environ["ENV"], sentry_dsn=os.environ["SENTRY_DSN"])
     config = yaml.safe_load(config)
-    autoscale(config["worker_types"])
+    autoscale(config["worker_types"], config.get("healthcheck_file"))
 
 
 @click.command()

--- a/src/k8s_autoscale/main.py
+++ b/src/k8s_autoscale/main.py
@@ -1,5 +1,6 @@
 import logging
 import os.path
+import pathlib
 import time
 
 import kubernetes
@@ -12,13 +13,21 @@ from k8s_autoscale.slo import get_new_worker_count
 logger = logging.getLogger(__name__)
 
 
-def autoscale(worker_types):
+def autoscale(worker_types, healthcheck_file=None):
     while True:
+        touch(healthcheck_file)
         for worker_type in worker_types:
             # TODO: run in parallel
             handle_worker_type(worker_type)
+            touch(healthcheck_file)
         logger.info("Sleeping between polls")
         time.sleep(180)
+
+
+def touch(flag_file):
+    if not flag_file:
+        return
+    pathlib.Path(flag_file).touch()
 
 
 def get_api(kube_config, kube_config_context):


### PR DESCRIPTION
Touch a flag file on each loop iteration to ensure that when we get stuck for some reason, the health check can notice it and k8s can restart us instead of waiting before it gets to a point where tasks aren't running and a human needs to notice and go poke manually.

Fixes #102