### PR TITLE
Bump max_replicas to 10 for mobile-t-signing

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -611,7 +611,7 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 1
+        max_replicas: 10
         avg_task_duration: 60
         slo_seconds: 120
         capacity_ratio: 1.0


### PR DESCRIPTION
android-components releases yield a ton of signing tasks, running them one at a time is wasteful.
