### PR TITLE
Add comm-1-tree-dev pool (bug 1869490)

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -349,6 +349,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: comm-1-tree-dev
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: dev-tree
+    deployment_name: tree-dev-relengworker-firefoxci-comm-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 1
+        avg_task_duration: 60
+        slo_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: gecko-1-tree-dev
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.