### PR TITLE
Reduce parallelization of gecko signing and beetmover scriptworkers

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -218,7 +218,7 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 80
+        max_replicas: 40
         avg_task_duration: 120
         slo_seconds: 240
         capacity_ratio: 1.0
@@ -862,7 +862,7 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 100
+        max_replicas: 50
         avg_task_duration: 60
         slo_seconds: 120
         capacity_ratio: 1.0


### PR DESCRIPTION
We've been seeing a lot of issues with hg.m.o load lately. One of the factors here is the bursty requests that chain of trust verification makes to fetch `/json-pushes` and `.taskcluster.yml`.

This patch cuts gecko-3 beetmover & signing max_replicas in half to 40 and 50 respectively, which are by far the largest pools (next closest is 20). This will slow down nightlies and releases to some degree, but hopefully will help hg.mozilla.org stay up.