### PR TITLE
Bug 1876573 - Add new mobile bitrise worker-types

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -111,6 +111,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: mobile-1-bitrise-dev
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: dev-bitrise
+    deployment_name: bitrise-dev-relengworker-firefoxci-mobile-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 20
+        avg_task_duration: 120
+        slo_seconds: 240
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: gecko-1-bouncer-dev
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -308,6 +308,34 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: mobile-1-bitrise
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-bitrise
+    deployment_name: bitrise-prod-relengworker-firefoxci-mobile-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 10
+        avg_task_duration: 60
+        slo_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
+  - worker_type: mobile-3-bitrise
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-bitrise
+    deployment_name: bitrise-prod-relengworker-firefoxci-mobile-3-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 10
+        avg_task_duration: 120
+        slo_seconds: 240
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: comm-1-bouncer
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
