### PR TITLE
Bug 1883936 - revert #151: Restore gecko signing and beetmover scriptworkers

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -218,7 +218,7 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 40
+        max_replicas: 80
         avg_task_duration: 120
         slo_seconds: 240
         capacity_ratio: 1.0
@@ -876,7 +876,7 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 50
+        max_replicas: 100
         avg_task_duration: 60
         slo_seconds: 120
         capacity_ratio: 1.0


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
