### PR TITLE
Add translations beetmover workers

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -111,6 +111,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: translations-services-1-beetmover-dev
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: dev-beetmover
+    deployment_name: beetmover-dev-relengworker-firefoxci-translations-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 5
+        avg_task_duration: 120
+        slo_seconds: 240
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: mobile-1-bitrise-dev
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
