### PR TITLE
fix: set a more reasonable value for bitrisescript average_task_duration

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -317,8 +317,8 @@ worker_types:
       algorithm: slo
       args:
         max_replicas: 10
-        avg_task_duration: 60
-        slo_seconds: 120
+        avg_task_duration: 1800
+        slo_seconds: 600
         capacity_ratio: 1.0
         min_replicas: 0
 
@@ -331,8 +331,8 @@ worker_types:
       algorithm: slo
       args:
         max_replicas: 10
-        avg_task_duration: 120
-        slo_seconds: 240
+        avg_task_duration: 1800
+        slo_seconds: 300
         capacity_ratio: 1.0
         min_replicas: 0
 


### PR DESCRIPTION
It's impossible to know the average task duration of these workers, because they entirely depend on how long the workflows take in Bitrise. It could be one minute or multiple hours. But 30 minutes seems like a reasonable middle ground.

Also bump up the SLO value so we don't spin up new nodes as quickly.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
