### PR TITLE
Fix multiple truthy expressions in eval

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -45,7 +45,7 @@ tasks:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
                   'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
-                  'tasks_for == "github-push"': ${event.ref}
+                  'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
                   'tasks_for == "github-release"': ''
                   'tasks_for in ["cron", "action"]': '${push.branch}'
                   'tasks_for == "pr-action"': '${push.base_branch}'


### PR DESCRIPTION
I don't know why this wasn't hit on dev or master...but we hit it on prod

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
