### PR TITLE
Bug 1896964 - Remove mobile-1/3-beetmover and mobile-3-github

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -55,20 +55,6 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
-  - worker_type: mobile-1-beetmover-dev
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: dev-beetmover
-    deployment_name: beetmover-dev-relengworker-firefoxci-mobile-1-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 20
-        avg_task_duration: 120
-        slo_seconds: 240
-        capacity_ratio: 1.0
-        min_replicas: 0
-
   - worker_type: xpi-1-beetmover-dev
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -224,34 +224,6 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
-  - worker_type: mobile-1-beetmover
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: prod-beetmover
-    deployment_name: beetmover-prod-relengworker-firefoxci-mobile-1-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 10
-        avg_task_duration: 60
-        slo_seconds: 120
-        capacity_ratio: 1.0
-        min_replicas: 0
-
-  - worker_type: mobile-3-beetmover
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: prod-beetmover
-    deployment_name: beetmover-prod-relengworker-firefoxci-mobile-3-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 10
-        avg_task_duration: 120
-        slo_seconds: 240
-        capacity_ratio: 1.0
-        min_replicas: 0
-
   - worker_type: xpi-1-beetmover
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"
@@ -397,20 +369,6 @@ worker_types:
     root_url: "https://firefox-ci-tc.services.mozilla.com"
     deployment_namespace: prod-github
     deployment_name: github-prod-relengworker-firefoxci-mobile-1-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 1
-        avg_task_duration: 60
-        slo_seconds: 120
-        capacity_ratio: 1.0
-        min_replicas: 0
-
-  - worker_type: mobile-3-github
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: prod-github
-    deployment_name: github-prod-relengworker-firefoxci-mobile-3-1
     autoscale:
       algorithm: slo
       args:


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.

Follow-up on https://github.com/mozilla-services/cloudops-infra/pull/5672