### PR TITLE
Bug 1817658 - Add TB pushmsix pools

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -223,6 +223,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: comm-1-pushmsix-dev
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: dev-pushmsix
+    deployment_name: pushmsix-dev-relengworker-firefoxci-comm-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 1
+        avg_task_duration: 360
+        slo_seconds: 720
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: gecko-1-shipit-dev
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -574,6 +574,34 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: comm-1-pushmsix
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-pushmsix
+    deployment_name: pushmsix-prod-relengworker-firefoxci-comm-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 1
+        avg_task_duration: 360
+        slo_seconds: 720
+        capacity_ratio: 1.0
+        min_replicas: 0
+
+  - worker_type: comm-3-pushmsix
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-pushmsix
+    deployment_name: pushmsix-prod-relengworker-firefoxci-comm-3-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 1
+        avg_task_duration: 360
+        slo_seconds: 720
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: comm-1-shipit
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
