### PR TITLE
put docker credentials in ~/.docker/config.json

### DIFF
--- a/taskcluster/docker/skopeo/push_image.sh
+++ b/taskcluster/docker/skopeo/push_image.sh
@@ -35,8 +35,9 @@ then
     echo "Skipping push because DRYRUN is 1"
 else
     echo "=== Generating dockercfg ==="
-    install -m 600 /dev/null $HOME/.dockercfg
-    curl $SECRET_URL | jq '.secret.docker.dockercfg' > $HOME/.dockercfg
+    mkdir -m 700 $HOME/.docker
+    curl $DEPLOY_SECRET_URL | jq '.secret.docker.dockercfg' > $HOME/.docker/config.json
+    chmod 600 $HOME/.docker/config.json
 
     echo "=== Pushing to docker hub ==="
     APP_VERSION="$(cat /version.txt)"


### PR DESCRIPTION
AFAICT .dockercfg doesn't support `auths`. This recipe is copied from https://github.com/mozilla-releng/shipit/blob/bc706a2cc2cee44b4a60a642333af87a7daaf3ea/taskcluster/docker/skopeo/push_image.sh, where it worked fine.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
