### PR TITLE
fix dockerhub secret var

### DIFF
--- a/taskcluster/docker/skopeo/push_image.sh
+++ b/taskcluster/docker/skopeo/push_image.sh
@@ -36,7 +36,7 @@ then
 else
     echo "=== Generating dockercfg ==="
     mkdir -m 700 $HOME/.docker
-    curl $DEPLOY_SECRET_URL | jq '.secret.docker.dockercfg' > $HOME/.docker/config.json
+    curl $SECRET_URL | jq '.secret.docker.dockercfg' > $HOME/.docker/config.json
     chmod 600 $HOME/.docker/config.json
 
     echo "=== Pushing to docker hub ==="


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
