### PR TITLE
feat: add lando prod deployments

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -1106,4 +1106,32 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: gecko-1-lando
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-lando
+    deployment_name: lando-prod-relengworker-firefoxci-gecko-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 3
+        avg_task_duration: 60
+        slo_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
+  - worker_type: gecko-3-lando
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-lando
+    deployment_name: lando-prod-relengworker-firefoxci-gecko-3-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 3
+        avg_task_duration: 60
+        slo_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
 healthcheck_file: /app/healthy


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.

The latter two bits are done. The former is https://github.com/mozilla-services/cloudops-infra/pull/6397, and a deployment will be done after that merges.