### PR TITLE
fix: don't tolerate any latency for landoscript

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -1128,9 +1128,9 @@ worker_types:
     autoscale:
       algorithm: slo
       args:
-        max_replicas: 3
+        max_replicas: 10
         avg_task_duration: 60
-        slo_seconds: 120
+        slo_seconds: 0
         capacity_ratio: 1.0
         min_replicas: 0
 


### PR DESCRIPTION
There are very few landoscript tasks, and the amount of time they take varies depending on the specific type of task. These tasks are all generally fairly urgent, so it's best to just ensure we just immediately spin up new replicas rather than wait.

We do this by increasing max replicas, and setting `slo_seconds` to 0, which should ensure that `still_pending` is always the actual number of tasks pending: https://github.com/mozilla-releng/k8s-autoscale/blob/5735a2a9d175dcd86609763335520832cf7cec2d/src/k8s_autoscale/slo.py#L19

See https://scriptworker-scripts.readthedocs.io/en/latest/scriptworkers-autoscaling.html for some further description of the algorithm used here.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
