### PR TITLE
Add prod config for mobile-3-github

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -378,6 +378,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: mobile-3-github
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-github
+    deployment_name: github-prod-relengworker-firefoxci-mobile-3-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 1
+        avg_task_duration: 60
+        slo_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: xpi-1-github
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
It got removed in 51ebd4fb1c5d71b87c0612e0ce37dc7f176624a1 because it wasn't necessary anymore but we need it again for firefox-ios

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
