### PR TITLE
feat: add translations L1 beetmover worker pool

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -280,6 +280,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: translations-1-beetmover
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-beetmover
+    deployment_name: beetmover-prod-relengworker-firefoxci-translations-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 10
+        avg_task_duration: 60
+        slo_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: mobile-1-bitrise
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
