### PR TITLE
Copy the healthcheck binary into the final image

### DIFF
--- a/taskcluster/docker/k8s_autoscale/Dockerfile
+++ b/taskcluster/docker/k8s_autoscale/Dockerfile
@@ -8,10 +8,6 @@ COPY . /app
 
 WORKDIR /app
 
-# %include docker.d
-COPY topsrcdir/docker.d/healthcheck /bin/healthcheck
-COPY topsrcdir/docker.d/init.sh /app/bin/init.sh
-
 # %include configs
 # %include README.rst
 # %include pyproject.toml
@@ -24,6 +20,10 @@ RUN uv venv
 RUN uv pip install .
 
 FROM python:$PYTHON_VERSION
+
+# %include docker.d
+COPY topsrcdir/docker.d/healthcheck /bin/healthcheck
+COPY topsrcdir/docker.d/init.sh /app/bin/init.sh
 
 WORKDIR /app
 RUN groupadd --gid 10001 app && \


### PR DESCRIPTION
We don't need either of those docker.d files in the builder, and the
/bin/healthcheck script ended up not being copied over from it. This
just moves the copy so they're directly included in the final image.