### PR TITLE
Don't scale down while there are claimed tasks (bug 1926654)

### DIFF
--- a/src/k8s_autoscale/slo.py
+++ b/src/k8s_autoscale/slo.py
@@ -1,13 +1,16 @@
 import math
 
 
-def get_new_worker_count(pending, running, args):
+def get_new_worker_count(counts, running, args):
     # TODO: verify all the args
     assert args["slo_seconds"] > args["avg_task_duration"]
+    pending = counts["pendingTasks"]
+    claimed = counts["claimedTasks"]
+    tasks = pending + claimed
     # In case we don't want to cover all the pending tasks
     pending = int(math.ceil(pending * args["capacity_ratio"]))
-    # Scale down only when we have no pending tasks
-    if pending == 0:
+    # Scale down when we have no more pending or claimed tasks
+    if tasks == 0:
         return -running
     # How many tasks a replica can process within our tolerance period
     new_tasks_per_replica = math.floor(args["slo_seconds"] / args["avg_task_duration"])

--- a/tests/test_sla.py
+++ b/tests/test_sla.py
@@ -8,29 +8,33 @@ args_capacity["capacity_ratio"] = 0.5
 
 
 @pytest.mark.parametrize(
-    "pending, running, args, expected",
+    "pending, claimed, running, args, expected",
     [
-        (0, 0, args, 0),
-        (1, 0, args, 1),
-        (10000, 0, args, 10),
-        (0, 10, args, -10),
-        (10, 20, args, 0),
-        (30, 0, args, 6),
-        (30, 2, args, 5),
-        (30, 5, args, 2),
-        (30, 6, args, 2),
-        (30, 7, args, 1),
-        (30, 8, args, 0),
+        (0, 0, 0, args, 0),
+        (1, 0, 0, args, 1),
+        (10000, 0, 0, args, 10),
+        (0, 0, 10, args, -10),
+        (10, 0, 20, args, 0),
+        (30, 0, 0, args, 6),
+        (30, 0, 2, args, 5),
+        (30, 0, 5, args, 2),
+        (30, 0, 6, args, 2),
+        (30, 0, 7, args, 1),
+        (30, 0, 8, args, 0),
+        (0, 5, 8, args, 0),
     ],
 )
-def test_process(pending, running, args, expected):
-    assert get_new_worker_count(pending, running, args) == expected
+def test_process(pending, claimed, running, args, expected):
+    assert (
+        get_new_worker_count({"pendingTasks": pending, "claimedTasks": claimed}, running, args)
+        == expected
+    )
 
 
 @pytest.mark.parametrize(
-    "pending, running, args, exception_type",
-    [(0, 0, {"slo_seconds": 10, "avg_task_duration": 20}, AssertionError)],
+    "pending, claimed, running, args, exception_type",
+    [(0, 0, 0, {"slo_seconds": 10, "avg_task_duration": 20}, AssertionError)],
 )
-def test_process_raises(pending, running, args, exception_type):
+def test_process_raises(pending, claimed, running, args, exception_type):
     with pytest.raises(exception_type):
-        get_new_worker_count(pending, running, args)
+        get_new_worker_count({"pendingTasks": pending, "claimedTasks": claimed}, running, args)


### PR DESCRIPTION
Scaling down as soon as the pending count goes to 0 has been a source of problems over the years because it requires a long termination grace period for containers and keeping that in sync in multiple places. Instead, we can wait until no tasks are either pending or claimed before we scale down.  Individual task run time will still be limited by scriptworker's task_max_timeout, which is easier to manage.