### PR TITLE
Bug 2025695 - relengworker: add xpi-1-lando and xpi-3-lando autoscaling

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -1198,4 +1198,32 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: xpi-1-lando
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-lando
+    deployment_name: lando-prod-relengworker-firefoxci-xpi-1-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 10
+        avg_task_duration: 1999
+        slo_seconds: 2000
+        capacity_ratio: 1.0
+        min_replicas: 0
+
+  - worker_type: xpi-3-lando
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-lando
+    deployment_name: lando-prod-relengworker-firefoxci-xpi-3-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 10
+        avg_task_duration: 1999
+        slo_seconds: 2000
+        capacity_ratio: 1.0
+        min_replicas: 0
+
 healthcheck_file: /app/healthy


### PR DESCRIPTION
[Bug 2025695](https://bugzilla.mozilla.org/show_bug.cgi?id=2025695)

## Summary

Adds `xpi-1-lando` and `xpi-3-lando` to `relengworker-prod/config.yml`. Follows the same autoscaling pattern as the existing `gecko-*-lando` workers.

## Merge order

1. mozilla-releng/fxci-config [#912](https://github.com/mozilla-releng/fxci-config/pull/912) — merged ✓
2. mozilla-releng/fxci-config [#933](https://github.com/mozilla-releng/fxci-config/pull/933) — merged ✓
3. mozilla-services/cloudops-infra [#6835](https://github.com/mozilla-services/cloudops-infra/pull/6835) (dev) — merged ✓
4. mozilla-services/cloudops-infra [#6848](https://github.com/mozilla-services/cloudops-infra/pull/6848) (chart secret) — merged ✓
5. k8s-sops: dev worker secrets — done ✓
6. mozilla-releng/k8s-autoscale [#264](https://github.com/mozilla-releng/k8s-autoscale/pull/264) (dev) — merged ✓
7. mozilla-releng/scriptworker-scripts [#1413](https://github.com/mozilla-releng/scriptworker-scripts/pull/1413) — merged ✓
8. mozilla-services/cloudops-infra [#6838](https://github.com/mozilla-services/cloudops-infra/pull/6838) (prod) — merged ✓
9. k8s-sops: prod worker secrets — manual step
10. **This PR** — merged ✓
11. mozilla-releng/fxci-config [#979](https://github.com/mozilla-releng/fxci-config/pull/979) — fix production lando action scope — merged ✓
12. mozilla-extensions/xpi-manifest [#271](https://github.com/mozilla-extensions/xpi-manifest/pull/271) — merged ✓

## Verification

Changes verified by inspection against existing gecko lando autoscaling entries (identical pattern).