### PR TITLE
chore: add temporary pool for testing mozcloud prod environment

### DIFF
--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -84,6 +84,20 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
+  - worker_type: gecko-3-balrog-mozcloud
+    provisioner: scriptworker-k8s
+    root_url: "https://firefox-ci-tc.services.mozilla.com"
+    deployment_namespace: prod-balrog
+    deployment_name: balrog-prod-relengworker-firefoxci-gecko-3-mozcloud-1
+    autoscale:
+      algorithm: slo
+      args:
+        max_replicas: 1
+        avg_task_duration: 60
+        slo_seconds: 120
+        capacity_ratio: 1.0
+        min_replicas: 0
+
   - worker_type: xpi-1-balrog
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
This will be used to verify that balrogscript is working correctly with the new MozCloud production environment on a project branch; it will never be used by Nightly et. al, and will be removed when testing is complete.

I still need to deal with these parts before merging this:
- [ ] **The pools exist**: The pools not only need to exist as configuration items in cloudops-infra, k8s-sops, and scriptworker-scripts, but the pools referenced in k8s-autoscale also need to be currently deployed and able to claim tasks.
