### PR TITLE
chore: remove gecko treescript workers

### DIFF
--- a/configs/relengworker-nonprod/config.yml
+++ b/configs/relengworker-nonprod/config.yml
@@ -419,20 +419,6 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
-  - worker_type: gecko-1-tree-dev
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: dev-tree
-    deployment_name: tree-dev-relengworker-firefoxci-gecko-1-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 1
-        avg_task_duration: 60
-        slo_seconds: 120
-        capacity_ratio: 1.0
-        min_replicas: 0
-
   - worker_type: mobile-1-tree-dev
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"

--- a/configs/relengworker-prod/config.yml
+++ b/configs/relengworker-prod/config.yml
@@ -1106,34 +1106,6 @@ worker_types:
         capacity_ratio: 1.0
         min_replicas: 0
 
-  - worker_type: gecko-1-tree
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: prod-tree
-    deployment_name: tree-prod-relengworker-firefoxci-gecko-1-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 1
-        avg_task_duration: 60
-        slo_seconds: 120
-        capacity_ratio: 1.0
-        min_replicas: 0
-
-  - worker_type: gecko-3-tree
-    provisioner: scriptworker-k8s
-    root_url: "https://firefox-ci-tc.services.mozilla.com"
-    deployment_namespace: prod-tree
-    deployment_name: tree-prod-relengworker-firefoxci-gecko-3-1
-    autoscale:
-      algorithm: slo
-      args:
-        max_replicas: 3
-        avg_task_duration: 300
-        slo_seconds: 600
-        capacity_ratio: 1.0
-        min_replicas: 0
-
   - worker_type: mobile-1-tree
     provisioner: scriptworker-k8s
     root_url: "https://firefox-ci-tc.services.mozilla.com"


### PR DESCRIPTION
We stopped using this after the Gecko repository migrated to github. These were already removed from the Jenkins deploy in https://github.com/mozilla-services/cloudops-infra/commit/ff356444c7d49c0d2a46b9a8ce31638242b2a546. Let's remove them from here so we can delete the workloads.